### PR TITLE
Preserving cwd for each tabs

### DIFF
--- a/lua/scope/core.lua
+++ b/lua/scope/core.lua
@@ -3,6 +3,7 @@ local utils = require("scope.utils")
 local M = {}
 
 M.cache = {}
+M.cwd = {}
 M.last_tab = 0
 
 function M.on_tab_new_entered()
@@ -17,6 +18,9 @@ function M.on_tab_enter()
             vim.api.nvim_buf_set_option(k, "buflisted", true)
         end
     end
+    if M.cwd[tab] ~= nil then
+        vim.fn.chdir(M.cwd[tab])
+    end
 end
 
 function M.on_tab_leave()
@@ -26,11 +30,13 @@ function M.on_tab_leave()
     for _, k in pairs(buf_nums) do
         vim.api.nvim_buf_set_option(k, "buflisted", false)
     end
+    M.cwd[tab] = vim.fn.getcwd()
     M.last_tab = tab
 end
 
 function M.on_tab_closed()
     M.cache[M.last_tab] = nil
+    M.cwd[M.last_tab] = nil
 end
 
 function M.print_summary()


### PR DESCRIPTION
This PR adds a new functionality to cache the `cwd` of each tabs.

I personally use tabs to separate my projects/repos, so it makes for me to have a `cwd` set differently for each project.

Let me know if you would like this feature to be configurable.