### PR TITLE
feat: add feature to move buffer between tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ require("scope").setup({})
 
 ```
 
+## ⚙️ Commands
+
+| <div style="width:200px">Command</div> | Description                                                                                                                                                                                                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:ScopeMoveBuf <tab_nr>`               | Move current buffer to the specified tab. <br> If tab_nr is omitted/invalid, `scope.nvim` will prompt for a tab number. <br> If current buf is the only buf in current tab, it will be "copied" to target to retain the layout, otherwise, it will be "moved" |
+
 ## 🚀 Extensions
 
 ### 🔭 Telescope

--- a/lua/scope/core.lua
+++ b/lua/scope/core.lua
@@ -59,18 +59,17 @@ function M.move_current_buf(opts)
         end
 
         target = tonumber(input)
-        if target == nil then
-            vim.api.nvim_err_writeln("Invalid target tab")
-            return
-        end
     end
 
-    if target < 0 or target > vim.fn.tabpagenr("$") or target == vim.api.nvim_get_current_tabpage() then
+    -- bufferline always display  tab number, not the handle. When scope use tab handle to store buffer info. So need to convert
+    local target_handle = vim.api.nvim_list_tabpages()[target]
+
+    if target_handle == nil then
         vim.api.nvim_err_writeln("Invalid target tab")
         return
     end
 
-    M.move_buf(vim.api.nvim_get_current_buf(), target)
+    M.move_buf(vim.api.nvim_get_current_buf(), target_handle)
 end
 
 function M.move_buf(bufnr, target)
@@ -82,7 +81,11 @@ function M.move_buf(bufnr, target)
     local buf_nums = utils.get_valid_buffers()
     if #buf_nums > 1 then
         vim.api.nvim_buf_set_option(bufnr, "buflisted", false)
-        vim.cmd("bprevious")
+
+        -- current buf are not in the current tab anymore, so we switch to the previous tab
+        if bufnr == vim.api.nvim_get_current_buf() then
+            vim.cmd("bprevious")
+        end
     end
 end
 return M

--- a/lua/scope/init.lua
+++ b/lua/scope/init.lua
@@ -33,6 +33,7 @@ function M._setup()
     if config.restore_state then
         vim.api.nvim_create_autocmd("SessionLoadPost", { group = group, callback = session.load_state }) --TODO: implement event behavior
     end
+    vim.api.nvim_create_user_command("ScopeMoveBuf", core.move_current_buf, { nargs = "?" }) --TODO: improve this
 end
 
 function M.setup(overrides)


### PR DESCRIPTION
I think it's useful to have a feature allow user to manually move buffer between tabs

Just add a command to allow that behavior `ScopeMoveBuf`