### PR TITLE
fix: use vim.api.nvim_set_current_tabpage instead of vim.cmd.tabnext

### DIFF
--- a/lua/telescope/_extensions/scope.lua
+++ b/lua/telescope/_extensions/scope.lua
@@ -139,7 +139,7 @@ local scope_buffers = function(opts)
                     actions.close(prompt_bufnr)
                     local tabi = find_buffer_tabindex(selection.bufnr)
                     if tabi ~= nil then
-                        vim.cmd("tabnext " .. tabi)
+                        vim.api.nvim_set_current_tabpage(tabi)
                     end
                     vim.cmd("buffer " .. selection.bufnr)
                 end)


### PR DESCRIPTION
The API `vim.api.nvim_get_current_tabpage` (which is used as a key in _M.cache_) returns tabpage handle which is not suitable for ` vim.cmd.tabnext`.

For instance, in the following scenario:
1) Open a file in the first tab, the tab handle is _1_
2) Create the second tab and open another file in it, the tab handle is _2_
3) Close the second tab
4) Create one more tab, visually it is second, but the handle is _3_ (per `nvim_get_current_tabpage`)
5) Open some file in the last tab
6) Move to the first tab, then try to go to the buffer in the last tab with `:Telescope scope buffers`
The following error is raised:
     _Vim(tabnext):E475: Invalid argument: 3: tabnext 3_

Since `:tabnext` accepts visual tab number (1,2,3,...) despite the real tabpage handle.