### PR TITLE
fix: revalidate for valid buffers on `:Telescope scope buffers`

### DIFF
--- a/lua/scope/core.lua
+++ b/lua/scope/core.lua
@@ -33,6 +33,12 @@ function M.on_tab_closed()
     M.cache[M.last_tab] = nil
 end
 
+function M.revalidate()
+    local tab = vim.api.nvim_get_current_tabpage()
+    local buf_nums = utils.get_valid_buffers()
+    M.cache[tab] = buf_nums
+end
+
 function M.print_summary()
     print("tab" .. " " .. "buf" .. " " .. "name")
     for tab, buf_item in pairs(M.cache) do

--- a/lua/telescope/_extensions/scope.lua
+++ b/lua/telescope/_extensions/scope.lua
@@ -62,6 +62,7 @@ end
 local scope_buffers = function(opts)
     opts = opts or {}
     opts = apply_cwd_only_aliases(opts)
+    scope_core.revalidate()
     local bufnrs = filter(
         function(b)
             if opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(b) then


### PR DESCRIPTION
Need to revalidate valid buffers for current tab when using `:Telescope scope buffers`, otherwise just deleted buffers are still visible.

Here is the example to reproduce the issue:
1) Open some file in the first tab
2) Create the second tab and open another file there
3) Move to the first tab and then again to the second (execute `:tabnext` two times),
this is needed for this test to allow `M.on_tab_leave` event to cache the buffers
4) Delete the buffer (it is in the the second tab) with `:bd`
5) Run `:Telescope scope buffers`
The result is: the just deleted buffer is still there.

This issue happens due to the fact that in _scope.lua_:
   `extend_without_duplicates` gathers buffers from `vim.api.nvim_list_bufs` (only _buflisted_) where the deleted buffer is filtered out, and from `get_all_scope_buffers` where deleted buffer is still in the cache. The cache is updated only on _TabLeave_.