### PR TITLE
fix: need to skip 'nil' values when serialize_state

### DIFF
--- a/lua/scope/session.lua
+++ b/lua/scope/session.lua
@@ -19,8 +19,8 @@ end
 function M.serialize_state()
     local core = require("scope.core")
     local scope_cache = {}
-    for k, v in pairs(core.cache) do
-        scope_cache[k] = utils.get_buffer_names(v)
+    for _, table in pairs(core.cache) do
+        scope_cache[#scope_cache + 1] = utils.get_buffer_names(table)
     end
     local state = {
         cache = scope_cache,


### PR DESCRIPTION
Issue: `M.serialize_state` doesn't take into account removed tabs correctly.

Consider the following example:
1) Open some file in first tab
2) Create another tab and open some file in it
3) Move to the first tab and close it
4) Save session

On restoring the session an error raises: `utils.lua:38: bad argument #1 to 'pairs' (table expected, got userdata)`

The issue happens due to the fact, that the first tab has index#1, removing it from the list-like table doesn't remove the first element actually, it will be 'nil' effectively.

Previous example steps lead to the following serialized JSON: `'[null,["SOME_FILE"]]'`

This PR fixes the issue in a way not to store the actual tab index, but rather an incrementing index in `scope_cache` list.

It is safe, since the stored index is not used actually anywhere. In fact, `M.deserialize_state` already takes into account that the tabs in restored VIM session will have indices from 1..N again. E.g. it uses: `cache[#cache + 1] = ...`


