### PR TITLE
Add Pre and Post Hooks for Tab Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,32 @@ Plug "tiagovla/scope.nvim"
 ```lua
 -- init.lua
 require("scope").setup({})
-
 ```
+
+### Hooks
+
+You can customize the behavior of Scope.nvim using the provided hooks in your configuration. Here's an example of how to set up the `pre_tab_enter` hook:
+
+```lua
+-- init.lua
+require("scope").setup({
+    hooks = {
+        pre_tab_enter = function()
+            -- Your custom logic to run before entering a tab
+        end,
+    },
+})
+```
+The pre_tab_enter hook allows you to define custom actions to run before entering a tab. This function is just one of several hooks you can use to further customize your experience with Scope.nvim.
+
+Here's an overview of the available hooks:
+
+- `pre_tab_enter`: Run custom logic before entering a tab.
+- `post_tab_enter`: Run custom logic after entering a tab.
+- `pre_tab_leave`: Run custom logic before leaving a tab.
+- `post_tab_leave`: Run custom logic after leaving a tab.
+- `pre_tab_close`: Run custom logic before closing a tab.
+- `post_tab_close`: Run custom logic after closing a tab.
 
 ## ⚙️ Commands
 

--- a/lua/scope/config.lua
+++ b/lua/scope/config.lua
@@ -1,5 +1,13 @@
 local config = {
     restore_state = false,
+    hooks = {
+        pre_tab_enter = nil,
+        post_tab_enter = nil,
+        pre_tab_leave = nil,
+        post_tab_leave= nil,
+        pre_tab_close= nil,
+        post_tab_close= nil,
+    },
 }
 
 function config.setup(overrides)

--- a/lua/scope/core.lua
+++ b/lua/scope/core.lua
@@ -1,4 +1,5 @@
 local utils = require("scope.utils")
+local config = require("scope.config")
 
 local M = {}
 
@@ -10,6 +11,9 @@ function M.on_tab_new_entered()
 end
 
 function M.on_tab_enter()
+    if config.hooks.pre_tab_enter ~= nil then
+        config.hooks.pre_tab_enter()
+    end
     local tab = vim.api.nvim_get_current_tabpage()
     local buf_nums = M.cache[tab]
     if buf_nums then
@@ -17,9 +21,15 @@ function M.on_tab_enter()
             vim.api.nvim_buf_set_option(k, "buflisted", true)
         end
     end
+    if config.hooks.post_tab_enter ~= nil then
+        config.hooks.post_tab_enter()
+    end
 end
 
 function M.on_tab_leave()
+    if config.hooks.pre_tab_leave ~= nil then
+        config.hooks.pre_tab_leave()
+    end
     local tab = vim.api.nvim_get_current_tabpage()
     local buf_nums = utils.get_valid_buffers()
     M.cache[tab] = buf_nums
@@ -27,10 +37,19 @@ function M.on_tab_leave()
         vim.api.nvim_buf_set_option(k, "buflisted", false)
     end
     M.last_tab = tab
+    if config.hooks.post_tab_leave ~= nil then
+        config.hooks.pre_tab_leave()
+    end
 end
 
 function M.on_tab_closed()
+    if config.hooks.pre_tab_close ~= nil then
+        config.hooks.pre_tab_close()
+    end
     M.cache[M.last_tab] = nil
+    if config.hooks.post_tab_close ~= nil then
+        config.hooks.post_tab_close()
+    end
 end
 
 function M.revalidate()


### PR DESCRIPTION
First and foremost, I'd like to express my gratitude to the author for creating this amazing plugin. It has undoubtedly elevated the Neovim tab workflow for many users.

### Motivation
This pull request aims to enhance the functionality of the Scope.nvim plugin by introducing pre and post hooks for tab-related events, including tabEnter, tabLeave, and tabClose. The motivation behind this enhancement is to provide users with more flexibility and control over the order of execution for custom tab event handlers. By implementing these hooks, users can ensure that their custom logic executes before tabEnter events and after tabLeave events, allowing for seamless customization of the tab management workflow.

### Benefits

- **Customization**: Users can now have their custom logic executed before tabEnter and after tabLeave events, ensuring that their code runs at the desired points in the tab switch process.
- **Order Control**: With these hooks, users have greater control over the execution order, preventing conflicts and allowing for a more tailored and efficient tab workflow.
- **Improved User Experience**: This enhancement elevates the user experience by making the Scope.nvim plugin even more flexible and adaptable to individual preferences.

### Consideration

This pull request introduces pre and post hooks for tab events in Scope.nvim, offering users more control over their tab management experience. I encourage the community to review these changes and provide feedback. Your insights and suggestions are important in determining whether these enhancements align with the plugin's objectives and can be integrated successfully. Thank you for your time and consideration.