### PR TITLE
fix(scope): call `post_tab_leave` on post tab leave

### DIFF
--- a/lua/scope/core.lua
+++ b/lua/scope/core.lua
@@ -38,7 +38,7 @@ function M.on_tab_leave()
     end
     M.last_tab = tab
     if config.hooks.post_tab_leave ~= nil then
-        config.hooks.pre_tab_leave()
+        config.hooks.post_tab_leave()
     end
 end
 


### PR DESCRIPTION
I discovered this while working on [an issue for barbar.nvim](https://github.com/romgrk/barbar.nvim/issues/556), and it *seems* like this is correct. Feel free to close if irrelevant.