### PR TITLE
fix - open the non active bufs from the non active tabs (#28)

### DIFF
--- a/lua/scope/utils.lua
+++ b/lua/scope/utils.lua
@@ -32,7 +32,31 @@ function U.get_buffer_names(buf_nums)
     return buf_names
 end
 
+function U.open_bufs_if_closed(buf_names)
+	for _, buf_name in pairs(buf_names) do
+		local buf_nums = vim.api.nvim_list_bufs()
+		local buf_is_open = false
+
+		for _, buf_num in pairs(buf_nums) do
+			local open_buf = vim.api.nvim_buf_get_name(buf_num)
+			if buf_name ~= "" and buf_name == open_buf then
+				buf_is_open = true
+			end
+			if buf_is_open then
+				break
+			end
+		end
+
+		if not buf_is_open then
+			vim.api.nvim_command("badd " .. buf_name)
+			local buf = vim.fn.bufnr(buf_name)
+			vim.api.nvim_buf_set_option(buf, "buflisted", false)
+		end
+	end
+end
+
 function U.get_buffer_ids(buf_names)
+    U.open_bufs_if_closed(buf_names)
     local buf_ids = {}
     local buf_nums = vim.api.nvim_list_bufs()
     for _, buf_name in pairs(buf_names) do


### PR DESCRIPTION
Fix for [PR #28](https://github.com/tiagovla/scope.nvim/issues/28).

### Problem:
When the session is restored, the buffers restored are incomplete, specifically:
- all buffers from the active tab
- but only the active buffer from the non-active tabs

Firstly, this behavior happens because the non-active buffers from the non-active tabs are not saved by `mksession`, which is correct, because normally (i.e. when _not_ using `scope.nvim`), all tabs have the same buffers, so `mksession` correctly saves only the active buffer from the non-active tabs.

### Solution:
`U.get_buffer_ids` gets called with the `vim.g.ScopeState`, which correctly includes all buffers, but it looks up their id in the restored ones, which is missing the non-active ones from the non-active pages.
Therefore, the solution is to simply make sure we open (as `unlisted`) the buffers that are missingm which I do in `U.open_bufs_if_closed`, then proceed as usual.

I haven't written comments in the source code, to be in line with the author's style.