### PR TITLE
fix: avoid opening empty buffer

### DIFF
--- a/lua/scope/utils.lua
+++ b/lua/scope/utils.lua
@@ -47,7 +47,7 @@ function U.open_bufs_if_closed(buf_names)
 			end
 		end
 
-		if not buf_is_open then
+		if not buf_is_open and buf_name ~= "" then
 			vim.api.nvim_command("badd " .. buf_name)
 			local buf = vim.fn.bufnr(buf_name)
 			vim.api.nvim_buf_set_option(buf, "buflisted", false)


### PR DESCRIPTION
When using scope.nvim + resession.nvim, if you have an empty buffer in a tab and closes nvim, you get this error message when nvim is opened again:

![image](https://github.com/user-attachments/assets/ef5c48cd-fe34-42fb-8d8c-578752f56c85)
