### PR TITLE
fix: invalid buffer error

### DIFF
--- a/lua/scope/core.lua
+++ b/lua/scope/core.lua
@@ -18,7 +18,9 @@ function M.on_tab_enter()
     local buf_nums = M.cache[tab]
     if buf_nums then
         for _, k in pairs(buf_nums) do
-            vim.api.nvim_buf_set_option(k, "buflisted", true)
+            if vim.api.nvim_buf_is_valid(k) then
+                vim.api.nvim_buf_set_option(k, "buflisted", true)
+            end
         end
     end
     if config.hooks.post_tab_enter ~= nil then


### PR DESCRIPTION
This fixes an error, when a buffer is wiped in another tab: 

```lua
Error detected while processing TabEnter Autocommands for "*":
Error executing lua callback: ...bda/.local/share/nvim/lazy/scope.nvim/lua/scope/core.lua:21: Invalid buffer id: 1
stack traceback:
  [C]: in function 'nvim_buf_set_option'
    .../.local/share/nvim/lazy/scope.nvim/lua/scope/core.lua:21: in function 
    .../.local/share/nvim/lazy/scope.nvim/lua/scope/core.lua:13
```